### PR TITLE
Release pyaging 0.3.1 using the standard Hugging Face cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: lint format update build install update-clocks-notebooks update-all-clocks verify-hf-auth verify-hf-data-repo-public create-hf-data-repo upload-clocks-to-hf upload-static-data-to-hf process-tutorials test test-tutorials docs version commit tag release release-slim
 
-VERSION ?= v0.3.0
+VERSION ?= v0.3.1
 HF_REPO_ID ?= lucascamillomd/pyaging-data
 HF_REPO_OWNER ?= lucascamillomd
 HF_STATIC_DIR ?= hf_static_data

--- a/clocks/huggingface/README.md
+++ b/clocks/huggingface/README.md
@@ -20,8 +20,8 @@ This public repository contains the model weights and data files used by
 - Root-level example files support the pyaging tutorials.
 - `supporting_files/` contains dependencies used to construct or document clocks.
 
-Files used by the Python package are intentionally stored at the repository root so
-`hf_hub_download(..., local_dir="pyaging_data")` preserves existing flat local paths.
+Files used by the Python package are intentionally stored at the repository root and
+downloaded through the standard Hugging Face cache.
 The `main` branch is the live data release and may change independently of the Python
 package version.
 

--- a/pyaging/__init__.py
+++ b/pyaging/__init__.py
@@ -4,4 +4,4 @@ from . import data, logger, models, utils
 from . import predict as pred
 from . import preprocess as pp
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/pyaging/data/_data.py
+++ b/pyaging/data/_data.py
@@ -27,7 +27,7 @@ def download_example_data(data_type: str, dir: str = "pyaging_data", verbose: bo
         'ENCFF386QWG', 'GSE65765', 'GSE193140', and 'blood_chemistry_example'.
 
     dir : str
-        The directory to deposit the downloaded file. Defaults to "pyaging_data".
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     verbose : bool
         Whether to log the output to console with the logger. Defaults to True.

--- a/pyaging/predict/_pred.py
+++ b/pyaging/predict/_pred.py
@@ -32,7 +32,7 @@ def predict_age(
         of clock names, by default "horvath2013".
 
     dir: str
-        The directory to deposit the downloaded file. Defaults to "pyaging_data".
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     batch_size: int
         The batch size for age inferece. Defaults to 1024.

--- a/pyaging/predict/_pred_utils.py
+++ b/pyaging/predict/_pred_utils.py
@@ -47,7 +47,7 @@ def load_clock(clock_name: str, device: str, dir: str, logger, indent_level: int
         Device to move clock to. Eithe 'cpu' or 'cuda'.
 
     dir : str
-        The directory to deposit the downloaded file.
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     logger : Logger
         A logger object used for logging information during the function execution.
@@ -347,7 +347,7 @@ def add_pred_ages_and_clock_metadata_adata(
         of this array should match the number of samples in `adata`.
 
     dir: str
-        The directory to deposit the downloaded file.
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     logger : Logger
         A logger object for logging the progress or relevant information during the operation.

--- a/pyaging/preprocess/_preprocess.py
+++ b/pyaging/preprocess/_preprocess.py
@@ -37,7 +37,7 @@ def bigwig_to_df(bw_files: Union[str, List[str]], dir: str = "pyaging_data", ver
         A list of bigWig file paths. If a single string is provided, it is converted to a list.
 
     dir : str
-        The directory to deposit the downloaded file. Defaults to "pyaging_data".
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     verbose: bool
         Whether to log the output to console with the logger. Defaults to True.

--- a/pyaging/preprocess/_preprocess_utils.py
+++ b/pyaging/preprocess/_preprocess_utils.py
@@ -330,7 +330,7 @@ def load_ensembl_metadata(dir: str, logger, indent_level: int = 1) -> pd.DataFra
     Parameters
     ----------
     dir : str
-        The directory to deposit the downloaded file.
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     logger : Logger
         A logging object for recording the progress and status of the download and filtering process.

--- a/pyaging/utils/_hf.py
+++ b/pyaging/utils/_hf.py
@@ -36,14 +36,16 @@ class PyAgingDownloadError(PyAgingHubError):
     """Raised when a data file cannot be downloaded."""
 
 
-def download_hf_file(filename: str, dir: str, logger=None, indent_level: int = 1) -> str:
-    """Download a pyaging data file and return its resolved local path."""
+def download_hf_file(filename: str, dir: str = "pyaging_data", logger=None, indent_level: int = 1) -> str:
+    """Download a pyaging data file to the standard Hugging Face cache.
+
+    ``dir`` is retained for backward compatibility but is no longer used.
+    """
     try:
         path = hf_hub_download(
             repo_id=REPO_ID,
             filename=filename,
             revision=REVISION,
-            local_dir=str(dir),
         )
     except LocalEntryNotFoundError as exc:
         raise PyAgingDownloadError(f"Could not download data file '{filename}' and no local copy is available") from exc

--- a/pyaging/utils/_utils.py
+++ b/pyaging/utils/_utils.py
@@ -75,13 +75,13 @@ def load_clock_metadata(dir: str, logger, indent_level: int = 2) -> dict:
     """
     Loads the clock metadata from Hugging Face.
 
-    This function downloads or resolves the metadata file from Hugging Face in the specified
-    directory, then reads and returns the metadata.
+    This function downloads or resolves the metadata file from the standard Hugging Face
+    cache, then reads and returns the metadata.
 
     Parameters
     ----------
     dir : str
-        The directory to deposit the downloaded file.
+        Retained for backward compatibility. Hugging Face files use its standard cache.
     logger : object
         Logger object used for logging information, warnings, and errors.
     indent_level : int, optional
@@ -161,7 +161,7 @@ def find_clock_by_doi(search_doi: str, dir: str = "pyaging_data") -> None:
     search_doi : str
         The DOI to search for in the aging clocks' metadata.
     dir : str
-        The directory to deposit the downloaded file. Defaults to 'pyaging_data'.
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     Returns
     -------
@@ -234,7 +234,7 @@ def cite_clock(clock_name: str, dir: str = "pyaging_data") -> None:
         The name of the aging clock for which citation information is to be retrieved.
         The function is case-insensitive to the clock name.
     dir : str
-        The directory to deposit the downloaded file. Defaults to 'pyaging_data'.
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     Returns
     -------
@@ -311,7 +311,7 @@ def show_all_clocks(dir: str = "pyaging_data") -> None:
     Parameters
     ----------
     dir : str
-        The directory to deposit the downloaded file. Defaults to 'pyaging_data'.
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     Returns
     -------
@@ -369,7 +369,7 @@ def get_clock_metadata(clock_name: str, dir: str = "pyaging_data") -> None:
     clock_name : str
         The name of the aging clock whose metadata is to be retrieved. The name is case-insensitive.
     dir : str
-        The directory to deposit the downloaded file. Defaults to 'pyaging_data'.
+        Retained for backward compatibility. Hugging Face files use its standard cache.
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyaging"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Python-based compendium of GPU-optimized aging clocks."
 authors = [
     {name = "Lucas Paulo de Lima Camillo", email = "lucas_camillo@alumni.brown.edu"}

--- a/tests/integration/test_hf_smoke.py
+++ b/tests/integration/test_hf_smoke.py
@@ -50,6 +50,9 @@ example_path = download_hf_file("blood_chemistry_example.pkl", data_dir)
 assert os.path.basename(metadata_path) == "all_clock_metadata.pt"
 assert os.path.basename(clock_path) == "horvath2013.pt"
 assert os.path.basename(example_path) == "blood_chemistry_example.pkl"
+assert not os.path.exists(data_dir)
+assert all(os.path.commonpath([path, os.environ["HF_HUB_CACHE"]]) == os.environ["HF_HUB_CACHE"]
+           for path in (metadata_path, clock_path, example_path))
 assert "horvath2013" in torch.load(metadata_path, weights_only=False)
 assert torch.load(clock_path, weights_only=False).metadata["clock_name"].lower() == "horvath2013"
 """

--- a/tests/test_release_configuration.py
+++ b/tests/test_release_configuration.py
@@ -93,7 +93,7 @@ def test_release_sdist_excludes_ignored_sentinels_and_preserves_catalog_files(tm
 
     package = project / "pyaging"
     package.mkdir()
-    package.joinpath("__init__.py").write_text('__version__ = "0.3.0"\n', encoding="utf-8")
+    package.joinpath("__init__.py").write_text('__version__ = "0.3.1"\n', encoding="utf-8")
     for relative_path in PRESERVED_STATIC_FILES:
         path = project / relative_path
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -111,9 +111,7 @@ def test_release_sdist_excludes_ignored_sentinels_and_preserves_catalog_files(tm
 
     assert members.isdisjoint(FORBIDDEN_SENTINELS)
     assert members >= PRESERVED_STATIC_FILES
-    assert hashlib.sha256(clean_sdist.read_bytes()).digest() == hashlib.sha256(
-        populated_sdist.read_bytes()
-    ).digest()
+    assert hashlib.sha256(clean_sdist.read_bytes()).digest() == hashlib.sha256(populated_sdist.read_bytes()).digest()
 
 
 def _load_workflow(name):
@@ -168,7 +166,7 @@ def test_makefile_uses_only_hf_publish_targets():
 
 
 def test_makefile_has_hf_release_defaults():
-    assert "VERSION ?= v0.3.0" in MAKEFILE
+    assert "VERSION ?= v0.3.1" in MAKEFILE
     assert "HF_REPO_ID ?= lucascamillomd/pyaging-data" in MAKEFILE
     assert "HF_REPO_OWNER ?= lucascamillomd" in MAKEFILE
     assert "HF_STATIC_DIR ?= hf_static_data" in MAKEFILE
@@ -246,7 +244,7 @@ def test_release_runs_steps_sequentially_in_one_recipe():
 
 def test_parallel_release_dry_run_preserves_publish_sequence():
     result = subprocess.run(
-        ["make", "-n", "-j4", "release-slim", "VERSION=v0.3.0"],
+        ["make", "-n", "-j4", "release-slim", "VERSION=v0.3.1"],
         check=True,
         capture_output=True,
         text=True,
@@ -262,7 +260,7 @@ def test_hf_repository_card_documents_layout_updates_and_access():
     text = HF_README.read_text(encoding="utf-8")
     assert "public repository" in text
     assert "repository root" in text
-    assert 'hf_hub_download(..., local_dir="pyaging_data")' in text
+    assert "downloaded through the standard Hugging Face cache" in text
     assert "`main` branch is the live data release" in text
     assert "Weights are uploaded before aggregate metadata" in text
     assert "need no Hugging Face token" in text
@@ -292,15 +290,13 @@ def test_release_workflow_is_tag_gated_and_publishes_after_verify():
 
 def test_release_verifies_version_tests_and_distribution_before_publish():
     workflow = _load_workflow("release.yml")
-    verify_commands = "\n".join(
-        step["run"] for step in workflow["jobs"]["verify"]["steps"] if "run" in step
-    )
+    verify_commands = "\n".join(step["run"] for step in workflow["jobs"]["verify"]["steps"] if "run" in step)
 
     assert "GITHUB_REF_NAME" in verify_commands
     assert "pyaging.__version__" in verify_commands
     assert "git fetch origin main --no-tags" in verify_commands
     assert 'git merge-base --is-ancestor "$GITHUB_SHA" origin/main' in verify_commands
-    assert 'not full_catalog and not online' in verify_commands
+    assert "not full_catalog and not online" in verify_commands
     assert "uv build" in verify_commands
     assert "twine check dist/*" in verify_commands
 
@@ -319,9 +315,7 @@ def test_release_uses_token_auth_without_oidc():
 def test_release_checkout_has_no_persisted_credentials_and_full_history():
     workflow = _load_workflow("release.yml")
     checkout = next(
-        step
-        for step in workflow["jobs"]["verify"]["steps"]
-        if step["uses"].startswith("actions/checkout@")
+        step for step in workflow["jobs"]["verify"]["steps"] if step["uses"].startswith("actions/checkout@")
     )
 
     assert checkout["with"]["persist-credentials"] == "false"
@@ -331,16 +325,14 @@ def test_release_checkout_has_no_persisted_credentials_and_full_history():
 def test_ci_excludes_large_and_online_tests():
     workflow = _load_workflow("ci.yml")
     triggers = workflow["on"]
-    unit_commands = "\n".join(
-        step["run"] for step in workflow["jobs"]["unit"]["steps"] if "run" in step
-    )
+    unit_commands = "\n".join(step["run"] for step in workflow["jobs"]["unit"]["steps"] if "run" in step)
 
     assert set(triggers) == {"push", "pull_request", "workflow_dispatch"}
     assert triggers["push"] == {"branches": ["main"]}
     assert triggers["pull_request"] == ""
     assert triggers["workflow_dispatch"] == ""
     assert workflow["permissions"] == {"contents": "read"}
-    assert 'not full_catalog and not online' in unit_commands
+    assert "not full_catalog and not online" in unit_commands
 
 
 def test_ci_covers_supported_platforms_and_tutorials():

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,6 +3,6 @@ from importlib.metadata import version
 import pyaging
 
 
-def test_package_version_is_0_3_0_everywhere():
-    assert pyaging.__version__ == "0.3.0"
-    assert version("pyaging") == "0.3.0"
+def test_package_version_is_0_3_1_everywhere():
+    assert pyaging.__version__ == "0.3.1"
+    assert version("pyaging") == "0.3.1"

--- a/tests/utils/test_hf.py
+++ b/tests/utils/test_hf.py
@@ -19,7 +19,7 @@ from pyaging.utils._hf import (
 )
 
 
-def test_download_hf_file_uses_pinned_repository_and_logs_path(monkeypatch, tmp_path):
+def test_download_hf_file_uses_pinned_repository_standard_cache_and_logs_path(monkeypatch, tmp_path):
     downloaded_path = str(tmp_path / "horvath2013.pt")
     hub_download = Mock(return_value=downloaded_path)
     logger = Mock()
@@ -32,9 +32,17 @@ def test_download_hf_file_uses_pinned_repository_and_logs_path(monkeypatch, tmp_
         repo_id="lucascamillomd/pyaging-data",
         filename="horvath2013.pt",
         revision="main",
-        local_dir=str(tmp_path),
     )
     logger.info.assert_called_once_with(f"Data available at {downloaded_path}", indent_level=3)
+
+
+def test_download_hf_file_keeps_dir_argument_for_backward_compatibility(monkeypatch):
+    hub_download = Mock(return_value="/hf-cache/horvath2013.pt")
+    monkeypatch.setattr("pyaging.utils._hf.hf_hub_download", hub_download)
+
+    download_hf_file("horvath2013.pt", "legacy-local-directory")
+
+    assert "local_dir" not in hub_download.call_args.kwargs
 
 
 def test_download_hf_file_maps_missing_entry_and_preserves_cause(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -4487,7 +4487,7 @@ wheels = [
 
 [[package]]
 name = "pyaging"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "anndata", version = "0.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## What changed

- stop passing `local_dir` to `hf_hub_download`, so models and datasets use the standard Hugging Face cache
- retain the existing `dir` parameter for backward-compatible calls
- add unit and live integration coverage proving no repo-local data directory is created
- bump the package and release defaults to 0.3.1

## Validation

- `uv run pytest -v` (108 passed, 2 deselected)
- `uv run pytest tests/integration/test_hf_smoke.py -m online -v` (1 passed)
- targeted Ruff checks and formatting checks
- `uv build` and `uvx twine check` for wheel and sdist
- confirmed PyPI version 0.3.1 is unused